### PR TITLE
Updated slack URL

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -35,7 +35,7 @@
 (function() {
   var slack_users_count = <?php echo $redis->get('slackin_active') ?>;
   var count = $('<span id="slack-count">').text(slack_users_count);
-  var socket = io('http://slack.socket.io');
+  var socket = io('http://socket.io/slack/');
   $('#menu-item-972 a').append(count);
 
   socket.on('active', function(val, total){


### PR DESCRIPTION
Originally I was going to update the header but it seems the nav bar lives in the WP theme itself which isn't available here.

I noticed that the Slack user script at the bottom of the page still references http://slack.socket.io which has been giving a 502 Bad Gateway for a while now.
