### PR TITLE
Fixup links to github repo

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -12,7 +12,7 @@
 
 	<footer id="colophon" class="site-footer" role="contentinfo">
 		<div class="site-info">
-			<span class="footer-left">SOCKET.IO IS OPEN-SOURCE (MIT). RUN BY <a href="https://github.com/Automattic/socket.io/graphs/contributors">CONTRIBUTORS</a>. </span>
+			<span class="footer-left">SOCKET.IO IS OPEN-SOURCE (MIT). RUN BY <a href="https://github.com/socketio/socket.io/graphs/contributors">CONTRIBUTORS</a>. </span>
       <span class="footer-right">
         <a href="https://twitter.com/socketio" class="twitter-follow-button" data-show-count="true" data-lang="en">Follow @socketio</a>
       </span>

--- a/home.php
+++ b/home.php
@@ -106,7 +106,7 @@
 							<h3>JOIN THE COMMUNITY</h3>
 							<ul style="margin-left: 0px; list-style-type: none;">
 								<li style="margin-bottom: 5px;">Real-time help? Find us on <a href="/slack">Slack</a></li>
-								<li style="margin-bottom: 5px;">Contribute code or report issues on <a href="https://github.com/Automattic/socket.io">GitHub</a></li>
+								<li style="margin-bottom: 5px;">Contribute code or report issues on <a href="https://github.com/socketio/socket.io">GitHub</a></li>
 							</ul>
 						</div>
 					</div>


### PR DESCRIPTION
Go to https://github.com/socketio/socket.io instead of https://github.com/Automattic/socket.io. The latter already redirects to the former.