### PR TITLE
Stop page jump on arrow click

### DIFF
--- a/public/assets/js/home.js
+++ b/public/assets/js/home.js
@@ -92,6 +92,7 @@
 
 $(document).ready(function() {
   $(".arrow > a").click(function() {
+    event.preventDefault();
     $('html, body').animate({
       scrollTop: $("#examples").offset().top
     }, 500);


### PR DESCRIPTION
I know this is really minor, but figured I'd mention it anyway.
Was just on the site and noticed that the site jumps instantly to the features section, and then scrolls down.
I believe just adding the preventDefault function should stop that blink at the beginning.