### PR TITLE
add Algolia DocSearch to docs sidebar; resolves #58

### DIFF
--- a/public/docs/client-api/index.html
+++ b/public/docs/client-api/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -620,6 +623,16 @@ socket.on(&#39;myevent&#39;, () =&gt; {
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/emit-cheatsheet/index.html
+++ b/public/docs/emit-cheatsheet/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li id="parent"><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -154,6 +157,16 @@ function onConnect(socket){
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/faq/index.html
+++ b/public/docs/faq/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li id="parent"><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -115,6 +118,16 @@
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -371,6 +374,16 @@ io.on('connection', function (socket) {
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/logging-and-debugging/index.html
+++ b/public/docs/logging-and-debugging/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li id="parent"><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -114,6 +117,16 @@
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/migrating-from-0-9/index.html
+++ b/public/docs/migrating-from-0-9/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -206,6 +209,16 @@ decoder.add(encodings[1]); // after adding the last element, 'decoded' is emitte
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/rooms-and-namespaces/index.html
+++ b/public/docs/rooms-and-namespaces/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -162,6 +165,16 @@ setInterval(function(){
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/server-api/index.html
+++ b/public/docs/server-api/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -777,6 +780,16 @@ socket.on(&#39;news&#39;, (data, callback) =&gt; {
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>

--- a/public/docs/using-multiple-nodes/index.html
+++ b/public/docs/using-multiple-nodes/index.html
@@ -20,6 +20,7 @@
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
   </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
 </head>
 
@@ -67,6 +68,8 @@
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
         <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
+        <li class="anchor"></li>
+        <li><input id="docsearch-input" type="text" placeholder="Search the docs" size="16" style="text-align: right;" /></li>
       </ul>
     </div>
 
@@ -145,6 +148,16 @@ io.adapter(redis({ host: 'localhost', port: 6379 }));</code></pre>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <script src="/assets/js/default.min.js"></script>
+
+<!-- Algolia DocSearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '58123f8fe0926bd32287730dbc483f6d',
+  indexName: 'socket_io',
+  inputSelector: '#docsearch-input',
+  debug: true  // Set debug to true if you want to inspect the dropdown
+});
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Hello socket.io maintainers 🙂!

As per an earlier email exchange with @darrachequesne, this PR adds [DocSearch](https://community.algolia.com/docsearch/documentation/) to the docs sidebar (see #58). DocSearch is a community project to add search functionality to documentation all across the web, for free. 👍 Disclaimer: I help maintain the project, and am also employed by the company that made it (Algolia - we do search as a service) - but DocSearch itself is [fully OSS](https://github.com/algolia/docsearch) (MIT).

As I understand it, you're currently considering a move to a new platform (possibly Next.js), and I'd be glad to help port this to whatever future templating system you decide on. Until then, I have tried to be as non-intrusive as possible, so I haven't added any files to the repo (i.e. css, etc), and have restricted my modifications to the docs section only.

Caveat: I'm not a designer (heh), but I tried my best to blend it into your aesthetic. The text area itself is the same size as the sidebar and is aligned right for consistency.
![image](https://user-images.githubusercontent.com/625232/33214012-5dbcfce0-d12a-11e7-81b0-d56afcedcf7e.png)

The default style (i.e. colours, etc) is minimalist and actually fits fairly well with your palette.
![image](https://user-images.githubusercontent.com/625232/33214120-d442e3d4-d12a-11e7-8b63-9b173047ef50.png)

That said, you're more than welcome to style it any way you like (the DocSearch docs have more details). ✨ 

I sincerely hope that you find this feature useful. If you have any questions, comments, or concerns, please don't hesitate to let me know. In any case, thanks for all your diligent work over the years on socket.io - keep up the great work!