### PR TITLE
HOTFIX: deleted relative from main-navigation > li

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -377,7 +377,6 @@ a:active {
 }
 .main-navigation li {
   float: left;
-  position: relative;
 }
 .main-navigation a {
   display: block;


### PR DESCRIPTION
When I browsed the site I found a bug related to the overlay of buttons on top of `#bar`.
`positino: relative` in `.main-navigation li {}` creates a bug associated with the Z axis.
