### PR TITLE
Fixed options for p2p server

### DIFF
--- a/source/_posts/20150714-p2p.md
+++ b/source/_posts/20150714-p2p.md
@@ -66,7 +66,7 @@ All code from this example is included in the <a href="https://github.com/socket
 We first setup the client with `autoUpgrade` set to false so that clients can upgrade the connection themselves. Set `numClients` to `10` to allow up to 10 clients to connect with each other.
 
 ```js
-var opts = {autoUpgrade: false, peerOpts: {numClients: 10}};
+var opts = {autoUpgrade: false, numClients: 10};
 var p2psocket = new P2P(socket, opts)
 ```
 


### PR DESCRIPTION
Fixed the order of values in the config object according to https://github.com/socketio/socket.io-p2p#api and https://github.com/feross/simple-peer/blob/master/README.md#api