### PR TITLE
 docs: re-fix editor window title position 

### DIFF
--- a/themes/socket.io/source/css/home.styl
+++ b/themes/socket.io/source/css/home.styl
@@ -139,7 +139,7 @@
 }
 
 .editor .body {
-  padding: 18px 10px;
+  padding: 0 18px 10px;
 }
 
 .editor .code {

--- a/themes/socket.io/source/css/home.styl
+++ b/themes/socket.io/source/css/home.styl
@@ -133,14 +133,13 @@
 .editor .title {
   text-align: center;
   display: inline-block;
-  width: 280px;
+  width: 250px;
   color: #766F79;
   vertical-align: middle;
 }
 
 .editor .body {
   padding: 18px 10px;
-  margin-top: -27px;
 }
 
 .editor .code {


### PR DESCRIPTION
propbably the same as #76 that solves #73 but without messing with negative margins.

the reason was that the the [edtor title](https://github.com/socketio/socket.io-website/blob/master/themes/socket.io/source/css/home.styl#L133-L139) were overflowing becasuse of its `width`.