### PR TITLE
Removing a backtick from the DEBUG statement

### DIFF
--- a/source/docs/logging-and-debugging.md
+++ b/source/docs/logging-and-debugging.md
@@ -18,7 +18,7 @@ You can see it in action for example on our homepage:
 The best way to see what information is available is to use the `*`:
 
 ```
-DEBUG=* node yourfile.js`
+DEBUG=* node yourfile.js
 ```
 
 or in the browser:


### PR DESCRIPTION
That backtick shouldn't be there. At least, my code didn't work it.