### PR TITLE
Update 20150120-native-socket-io-and-android.md

### DIFF
--- a/source/_posts/20150120-native-socket-io-and-android.md
+++ b/source/_posts/20150120-native-socket-io-and-android.md
@@ -114,7 +114,7 @@ import com.github.nkzawa.emitter.Emitter;
 
 private Emitter.Listener onNewMessage = new Emitter.Listener() {
     @Override
-    public void call(final Object.. args) {
+    public void call(final Object... args) {
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
Syntax error when declaring method *call* for *Listener*, must be *Object...* (three dots).