### PR TITLE
Change window size to 42%

### DIFF
--- a/themes/socket.io/source/css/home.styl
+++ b/themes/socket.io/source/css/home.styl
@@ -102,7 +102,7 @@
 
 .window {
   border: 1px solid rgb(195, 195, 195);
-  width: 40%;
+  width: 42%;
   border-radius: 4px;
   -webkit-box-shadow: 0px 2px 3px 0px rgba(50, 50, 50, 0.11);
   -moz-box-shadow: 0px 2px 3px 0px rgba(50, 50, 50, 0.11);


### PR DESCRIPTION
Hello 👋

On chrome and firefox the code in the left `window` stretches past the container. Changing the width to 42% seems to fix the issue. 

Here is a screenshot of the issue.

<img width="1280" alt="screenshot 2019-02-18 at 10 17 35" src="https://user-images.githubusercontent.com/3131401/52940569-2d874a80-3367-11e9-8ce6-52150efabe55.png">

Hope this helps 😄 