### PR TITLE
Add clarification on hosting the client JS file

### DIFF
--- a/source/get-started/chat.md
+++ b/source/get-started/chat.md
@@ -141,7 +141,6 @@ http.listen(3000, function(){
 
 Notice that I initialize a new instance of `socket.io` by passing the `http` (the HTTP server) object. Then I listen on the `connection` event for incoming sockets, and I log it to the console.
 
-You can either download the client JS file to a local directory or use the [CDN](https://cdn.socket.io/socket.io-1.2.0.js). Just make sure to change the `src` of the script tag depending on where the file is being hosted.
 
 Now in index.html I add the following snippet before the `</body>`:
 
@@ -152,7 +151,9 @@ Now in index.html I add the following snippet before the `</body>`:
 </script>
 ```
 
-That’s all it takes to load the `socket.io-client`, which exposes a `io` global, and then connect.
+That’s all it takes to load the `socket.io-client`, which exposes a `io` global (and the endpoint `GET /socket.io/socket.io.js`), and then connect.
+
+If you would like to use the local version of the client-side JS file, you can find it at `node_modules/socket.io-client/dist/socket.io.js`.
 
 Notice that I’m not specifying any URL when I call `io()`, since it defaults to trying to connect to the host that serves the page.
 

--- a/source/get-started/chat.md
+++ b/source/get-started/chat.md
@@ -141,6 +141,8 @@ http.listen(3000, function(){
 
 Notice that I initialize a new instance of `socket.io` by passing the `http` (the HTTP server) object. Then I listen on the `connection` event for incoming sockets, and I log it to the console.
 
+You can either download the client JS file to a local directory or use the [CDN](https://cdn.socket.io/socket.io-1.2.0.js). Just make sure to change the `src` of the script tag depending on where the file is being hosted.
+
 Now in index.html I add the following snippet before the `</body>`:
 
 ```html


### PR DESCRIPTION
Currently, the example on GitHub hosted [here](https://github.com/socketio/chat-example/blob/master/index.html) specifies a CDN to host the client-side JS.

```html
<script src="https://cdn.socket.io/socket.io-1.2.0.js"></script>
```

However, it may be good to be explicit that socket.io exposes the API endpoint for them automatically, but they can use a CDN if they choose or use the one in the `dist` folder, given that they make the appropriate change to the script's `src` tag. As a new user to `socket.io`, I didn't realize that `/socket.io/socket.io.js` was automatically exposed.