### PR TITLE
Updated android lib version to the newest

### DIFF
--- a/source/_posts/20150120-native-socket-io-and-android.md
+++ b/source/_posts/20150120-native-socket-io-and-android.md
@@ -32,7 +32,7 @@ For this app, we just add the dependency to `build.gradle`:
 // app/build.gradle
 dependencies {
     ...
-    compile 'com.github.nkzawa:socket.io-client:0.3.0'
+    implementation 'com.github.nkzawa:socket.io-client:0.6.0'
 }
 ```
 


### PR DESCRIPTION
The current version of the android library on the documentation is wrong, I updated it with the newest version from the [maven repo](https://mvnrepository.com/artifact/com.github.nkzawa/socket.io-client/0.5.0)