### PR TITLE
plural

### DIFF
--- a/source/index.ejs
+++ b/source/index.ejs
@@ -178,7 +178,7 @@
           <div class="information-entry">
             <h3>USED BY EVERYONE</h3>
             <p>From Microsoft Office, Yammer, Zendesk, Trello... to hackathon winners and little startups.</p>
-            <p>One of the most powerful JavaScript frameworks on GitHub, and most depended-upon npm module.</p>
+            <p>One of the most powerful JavaScript frameworks on GitHub, and most depended-upon npm modules.</p>
           </div>
         </div>
 


### PR DESCRIPTION
*module* should be pluralised like *frameworks*.  Socket.io is [not](https://www.npmjs.com/browse/depended) *the* most depended-upon npm module.