### PR TITLE
update client-api.md

### DIFF
--- a/source/docs/client-api.md
+++ b/source/docs/client-api.md
@@ -601,7 +601,7 @@ socket.on('error', (error) => {
 
 ## Event: 'disconnect'
 
-  - `reason` _(String)_ either 'io server disconnect', 'io client disconnect', or 'ping timeout'
+  - `reason` _(String)_ either 'io server disconnect', 'io client disconnect', 'ping timeout', or 'transport close'
 
 Fired upon a disconnection.
 


### PR DESCRIPTION
Added a missing return value in the Event 'disconnect'. I tried it and when the client leaves the app, it returns 'transport close', which is not mentioned as a return value