### PR TITLE
Update the index.md file with the correct spelling for packet

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -61,7 +61,7 @@ io.on('connection', function(socket){
 
 ## What Socket.IO is not
 
-Socket.IO is **NOT** a WebSocket implementation. Although Socket.IO indeed uses WebSocket as a transport when possible, it adds some metadata to each packet: the packet type, the namespace and the ack id when a message acknowledgement is needed. That is why a WebSocket client will not be able to successfully connect to a Socket.IO server, and a Socket.IO client will not be able to connect to a WebSocket server either. Please see the protocol specification [here](https://github.com/socketio/socket.io-protocol).
+Socket.IO is **NOT** a WebSocket implementation. Although Socket.IO indeed uses WebSocket as a transport when possible, it adds some metadata to each packet: the packet type, the namespace and the packet id when a message acknowledgement is needed. That is why a WebSocket client will not be able to successfully connect to a Socket.IO server, and a Socket.IO client will not be able to connect to a WebSocket server either. Please see the protocol specification [here](https://github.com/socketio/socket.io-protocol).
 
 ```js
 // WARNING: the client will NOT be able to connect!


### PR DESCRIPTION
### What does this PR do?

Correct the spelling of packet in `What Socket.IO is not` section of index.md file