### PR TITLE
updated documentation for default room

### DIFF
--- a/source/docs/rooms-and-namespaces.md
+++ b/source/docs/rooms-and-namespaces.md
@@ -72,7 +72,7 @@ To leave a channel you call `leave` in the same fashion as `join`. Both methods 
 
 ## Default room
 
-Each `Socket` in Socket.IO is identified by a random, unguessable, unique identifier `Socket#id`. For your convenience, each socket automatically joins a room identified by this id.
+Each `Socket` in Socket.IO is identified by a random, unguessable, unique identifier `Socket#id`. For your convenience, each socket automatically joins a room identified by its own id.
 
 This makes it easy to broadcast messages to other sockets:
 


### PR DESCRIPTION
making it clear that each socket joins  by default a room which is identified by "its own id". Earlier it said "this id" which may imply that all sockets connect to "this id".