### PR TITLE
Update Outdated Link to iOS Client

### DIFF
--- a/source/docs/faq.md
+++ b/source/docs/faq.md
@@ -19,7 +19,7 @@ Take a look at [this tutorial](/socket-io-with-apache-cordova/).
 
 ## Socket.IO on iOS?
 
-Take a look at [SIOSocket](https://github.com/MegaBits/SIOSocket).
+Take a look at [socket.io-client-swift](https://github.com/socketio/socket.io-client-swift).
 
 ## Socket.IO on Android?
 


### PR DESCRIPTION
I noticed your FAQ site links to `SIOSocket`, which links back to your own `socket.io-client-swift`. So here's the shortcut 😉 
