### PR TITLE
docs: Fixed grammar typo. Closes #112

### DIFF
--- a/source/get-started/chat.md
+++ b/source/get-started/chat.md
@@ -15,7 +15,7 @@ This means that the server can *push* messages to clients. Whenever you write a 
 
 ## The web framework
 
-The first goal is to setup a simple HTML webpage that serves out a form and a list of messages. We’re going to use the Node.JS web framework `express` to this end. Make sure [Node.JS](https://nodejs.org) is installed.
+The first goal is to set up a simple HTML webpage that serves out a form and a list of messages. We’re going to use the Node.JS web framework `express` to this end. Make sure [Node.JS](https://nodejs.org) is installed.
 
 First let’s create a `package.json` manifest file that describes our project. I recommend you place it in a dedicated empty directory (I’ll call mine `chat-example`).
 


### PR DESCRIPTION
Referencing issue #112. Only found one instance of "setup" where the correct use was "set up".