### PR TITLE
docs: redirect link to correct page.

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -294,4 +294,4 @@ Any serializable data structures can be emitted, including:
 
 ### Multiplexing support
 
-In order to create separation of concerns within your application (for example per module, or based on permissions), Socket.IO allows you to create several [Namespaces](/docs/rooms-and-namespaces/#Namespaces), which will act as separate communication channels but will share the same underlying connection.
+In order to create separation of concerns within your application (for example per module, or based on permissions), Socket.IO allows you to create several [Namespaces](/docs/namespaces), which will act as separate communication channels but will share the same underlying connection.


### PR DESCRIPTION
Change link for namespaces to redirect you to the namespace document. The original link was redirecting to the rooms document.