### PR TITLE
changed word from an to a as a result of the the word `union` after it

### DIFF
--- a/source/docs/v3/rooms.md
+++ b/source/docs/v3/rooms.md
@@ -36,7 +36,7 @@ You can emit to several rooms at the same time:
 io.to('room1').to('room2').to('room3').emit('some event');
 ```
 
-In that case, an <a href="https://en.wikipedia.org/wiki/Union_(set_theory)">union</a> is performed: every socket that is at least in one of the rooms will get the event **once** (even if the socket is in two or more rooms).
+In that case, a <a href="https://en.wikipedia.org/wiki/Union_(set_theory)">union</a> is performed: every socket that is at least in one of the rooms will get the event **once** (even if the socket is in two or more rooms).
 
 You can also broadcast to a room from a given socket:
 


### PR DESCRIPTION
Made a little fix on line 39 from `an union` to `a union`