### PR TITLE
Update client-initialization.md

### DIFF
--- a/source/docs/v3/client-initialization.md
+++ b/source/docs/v3/client-initialization.md
@@ -21,7 +21,7 @@ In the examples below, the `io` object comes either from:
 
 ```js
 // ES6 import
-import { io } from 'socket.io-client';
+import { connect as io } from 'socket.io-client';
 // CommonJS
 const io = require('socket.io-client');
 ```


### PR DESCRIPTION
Change es6 import statement to correlate with correct exposed module name. When using old statement, TS breaks.