### PR TITLE
Fixed import syntax example

### DIFF
--- a/source/docs/v3/client-api.md
+++ b/source/docs/v3/client-api.md
@@ -23,7 +23,7 @@ Exposed as the `io` namespace in the standalone build, or the result of calling 
 ```js
 const io = require('socket.io-client');
 // or with import syntax
-import { io } from 'socket.io-client';
+import io from 'socket.io-client';
 ```
 
 ### io.protocol


### PR DESCRIPTION
io is exported as both a default export "io" and an exported member "{io}".

Although both will work, @types/socket.io-client is marked as the default import being the preferred syntax

```
// index.d.ts from @types/socket.io-client

declare module 'socket.io-client' {
	export = io;
}
```