### PR TITLE
Fix `on('reconnect_attempt')` event name

### DIFF
--- a/source/docs/v4/client-socket-instance.md
+++ b/source/docs/v4/client-socket-instance.md
@@ -59,7 +59,7 @@ The Socket instance emits three special events:
 Please note that since Socket.IO v3, the Socket instance does not emit any event related to the reconnection logic anymore. You can listen to the events on the Manager instance directly:
 
 ```js
-socket.io.on("reconnection_attempt", () => {
+socket.io.on("reconnect_attempt", () => {
   // ...
 });
 


### PR DESCRIPTION
Based on findings in /node_modules/socket.io-client/build/manager.js:338 (screenshot below)

![image](https://user-images.githubusercontent.com/10461863/113510524-99cf6300-955b-11eb-8e15-77fdd1325247.png)

Also get a type error when using 'reconnection_attempt'