### PR TITLE
Update express-session usage section in FAQs

### DIFF
--- a/source/docs/v4/faq.md
+++ b/source/docs/v4/faq.md
@@ -71,6 +71,3 @@ io.on('connection', (socket) => {
 const port = process.env.PORT || 3000;
 server.listen(port, () => console.log('server listening on port ' + port));
 ```
-
-
-

--- a/source/docs/v4/faq.md
+++ b/source/docs/v4/faq.md
@@ -47,6 +47,22 @@ io.use((socket, next) => {
 });
 
 io.on('connection', (socket) => {
+  // Middleware to reload session between emits. Without this the session will be constant
+  // even if it is changed else where (ie. User logs out).
+  socket.use((packet, next) => {
+    socket.request.session.reload((error) => 
+    {
+      if (error) {
+        return next(new Error("There has been an error reloading the session."));
+      }
+      next();
+    })
+  });
+  
+  socket.on("message", () => {
+    console.log(socket.request.session.name + " has sent a message!")
+  })
+
   const session = socket.request.session;
   session.connections++;
   session.save();
@@ -55,3 +71,6 @@ io.on('connection', (socket) => {
 const port = process.env.PORT || 3000;
 server.listen(port, () => console.log('server listening on port ' + port));
 ```
+
+
+

--- a/source/docs/v4/faq.md
+++ b/source/docs/v4/faq.md
@@ -48,7 +48,7 @@ io.use((socket, next) => {
 
 io.on('connection', (socket) => {
   // Middleware to reload session between emits. Without this the session will be constant
-  // even if it is changed else where (ie. User logs out).
+  // even if it is changed elsewhere (ie. User logs out).
   socket.use((packet, next) => {
     socket.request.session.reload((error) => 
     {


### PR DESCRIPTION
The example for express-session usage is great, I just wanted to add an example for reloading the sessions between emits. Without some middleware to handle reloading express-session the user's session could incorrectly persist during the entire connection. This could lead to security implications due to the user being logged in for the entire connection. 