### PR TITLE
attach connection listener before creating client

### DIFF
--- a/source/docs/v3/testing.md
+++ b/source/docs/v3/testing.md
@@ -136,10 +136,10 @@ test("setup", (t) => {
   io = new Server(httpServer);
   httpServer.listen(() => {
     const port = httpServer.address().port;
-    clientSocket = new Client(`http://localhost:${port}`);
     io.on("connection", (socket) => {
       serverSocket = socket;
     });
+    clientSocket = new Client(`http://localhost:${port}`);
     clientSocket.on("connect", t.end);
   });
 });

--- a/source/docs/v3/testing.md
+++ b/source/docs/v3/testing.md
@@ -36,10 +36,10 @@ describe("my awesome project", () => {
     io = new Server(httpServer);
     httpServer.listen(() => {
       const port = httpServer.address().port;
-      clientSocket = new Client(`http://localhost:${port}`);
       io.on("connection", (socket) => {
         serverSocket = socket;
       });
+      clientSocket = new Client(`http://localhost:${port}`);
       clientSocket.on("connect", done);
     });
   });

--- a/source/docs/v3/testing.md
+++ b/source/docs/v3/testing.md
@@ -86,10 +86,10 @@ describe("my awesome project", () => {
     io = new Server(httpServer);
     httpServer.listen(() => {
       const port = httpServer.address().port;
-      clientSocket = new Client(`http://localhost:${port}`);
       io.on("connection", (socket) => {
         serverSocket = socket;
       });
+      clientSocket = new Client(`http://localhost:${port}`);
       clientSocket.on("connect", done);
     });
   });

--- a/source/docs/v4/testing.md
+++ b/source/docs/v4/testing.md
@@ -136,10 +136,10 @@ test("setup", (t) => {
   io = new Server(httpServer);
   httpServer.listen(() => {
     const port = httpServer.address().port;
-    clientSocket = new Client(`http://localhost:${port}`);
     io.on("connection", (socket) => {
       serverSocket = socket;
     });
+    clientSocket = new Client(`http://localhost:${port}`);
     clientSocket.on("connect", t.end);
   });
 });

--- a/source/docs/v4/testing.md
+++ b/source/docs/v4/testing.md
@@ -36,10 +36,10 @@ describe("my awesome project", () => {
     io = new Server(httpServer);
     httpServer.listen(() => {
       const port = httpServer.address().port;
-      clientSocket = new Client(`http://localhost:${port}`);
       io.on("connection", (socket) => {
         serverSocket = socket;
       });
+      clientSocket = new Client(`http://localhost:${port}`);
       clientSocket.on("connect", done);
     });
   });

--- a/source/docs/v4/testing.md
+++ b/source/docs/v4/testing.md
@@ -86,10 +86,10 @@ describe("my awesome project", () => {
     io = new Server(httpServer);
     httpServer.listen(() => {
       const port = httpServer.address().port;
-      clientSocket = new Client(`http://localhost:${port}`);
       io.on("connection", (socket) => {
         serverSocket = socket;
       });
+      clientSocket = new Client(`http://localhost:${port}`);
       clientSocket.on("connect", done);
     });
   });


### PR DESCRIPTION
In the Testing examples (both v3 and v4) the client is created before the listener for connection events is created. Looks like this is no problem when using `socket.io@3` or `socket.io@4` together with the respective clients. However, it is a problem when using `socket.io@^3.1.x` together with a `socket.io-client@2` client having the `allowEIO3: true` option enabled on the server. Looks like the `"connection"` event passes before the listener is attached. Therefore, we should switch the order of these statements. These examples will continue to work on v3 and v4.