### PR TITLE
Smooth scroll while navigating through page

### DIFF
--- a/themes/socket.io/source/css/style.styl
+++ b/themes/socket.io/source/css/style.styl
@@ -13,6 +13,7 @@
 
 html
   font-size: 62.5%
+  scroll-behavior: smooth
 
 html, body, #container
   height: 100%


### PR DESCRIPTION
I added only one line of CSS `scroll-behavior: smooth`. 
This makes smooth scrolling by links (by clicking `<a href="#somewhere-in-page" />`). It could be noticed in main page and actually anywhere else, because I edited the main theme CSS

![PRdemonstartion](https://user-images.githubusercontent.com/59529959/118393356-b9d56480-b679-11eb-9364-ebb361066b2e.gif)

