### PR TITLE
Move listen command to a worker

### DIFF
--- a/source/docs/v4/using-multiple-nodes.md
+++ b/source/docs/v4/using-multiple-nodes.md
@@ -259,7 +259,6 @@ if (cluster.isMaster) {
   setupMaster(httpServer, {
     loadBalancingMethod: "least-connection", // either "random", "round-robin" or "least-connection"
   });
-  httpServer.listen(3000);
 
   for (let i = 0; i < numCPUs; i++) {
     cluster.fork();
@@ -276,7 +275,7 @@ if (cluster.isMaster) {
   const io = new Server(httpServer);
   io.adapter(redisAdapter({ host: "localhost", port: 6379 }));
   setupWorker(io);
-
+  httpServer.listen(3000);
   io.on("connection", (socket) => {
     /* ... */
   });


### PR DESCRIPTION
Usage of "listen" command in primary thread cause the process of http server can hangup and stop to receive connections.
I ran into this in latest versions of express and socket.io.
With "listen" in worker thread, all connections handle correctly.

This approach described in nodejs docs:
https://nodejs.org/docs/latest/api/cluster.html