### PR TITLE
docs: update npm imports example

### DIFF
--- a/source/docs/v4/client-initialization.md
+++ b/source/docs/v4/client-initialization.md
@@ -19,10 +19,15 @@ In the examples below, the `io` object comes either from:
 - NPM
 
 ```js
-// ES6 import or TypeScript
+// CommonJS strict
+const { io } = require("socket.io-client");
+// or
 import { io } from "socket.io-client";
-// CommonJS
+
+// NodeJS
 const io = require("socket.io-client");
+// or
+import io from "socket.io-client";
 ```
 
 ## From the same domain


### PR DESCRIPTION
The JS module ecosystem is super confusing. What I do know is that my client project is server-side rendered, therefore the code executes inside of Node, and `io` is the default export from the `socket.io-client` module, not a property on the module.

This is the clearest answer I could get to determine how the module would be imported/exported:
https://stackoverflow.com/questions/46708062/what-environment-is-expected-by-iftypeof-exports-object-in-umd-definit