### PR TITLE
Spelling: “An unique identifier” → “A unique identifier”

### DIFF
--- a/source/docs/v3/client-api.md
+++ b/source/docs/v3/client-api.md
@@ -300,7 +300,7 @@ More information can be found [here](/docs/v3/client-socket-instance/).
 
   - _(String)_
 
-An unique identifier for the socket session. Set after the `connect` event is triggered, and updated after the `reconnect` event.
+A unique identifier for the socket session. Set after the `connect` event is triggered, and updated after the `reconnect` event.
 
 ```js
 const socket = io("http://localhost");


### PR DESCRIPTION
Spelling mistake caught on the [Socket.IO Client API description for `socket.id`](https://socket.io/docs/v3/client-api/index.html#socket-id).