### PR TITLE
Update links to msgpack-parser to socket.io org

### DIFF
--- a/blog/2020-10-03-monthly-update.md
+++ b/blog/2020-10-03-monthly-update.md
@@ -64,7 +64,7 @@ So, let's [discuss](https://github.com/socketio/socket.io/discussions)!
   - [socket.io-parser@3.3.1](https://github.com/socketio/socket.io-parser/releases/tag/3.3.1) (included in `socket.io-client{% raw %}@{% endraw %}2.3.1`)
 
 - [socket.io-json-parser@2.1.1](https://github.com/darrachequesne/socket.io-json-parser/releases/tag/2.1.1)
-- [socket.io-msgpack-parser@2.2.1](https://github.com/darrachequesne/socket.io-msgpack-parser/releases/tag/2.2.1)
+- [socket.io-msgpack-parser@2.2.1](https://github.com/socketio/socket.io-msgpack-parser/releases/tag/2.2.1)
 
 More information about how to use those custom parsers can be found [here](https://github.com/socketio/socket.io/tree/master/examples/custom-parsers).
 

--- a/blog/2020-11-23-monthly-update.md
+++ b/blog/2020-11-23-monthly-update.md
@@ -56,7 +56,7 @@ If you find a typo, please open an issue here: https://github.com/socketio/socke
 
 - [socket.io-redis@6.0.1](https://github.com/socketio/socket.io-redis/releases/tag/6.0.1)
 
-- [socket.io-msgpack-parser@3.0.1](https://github.com/darrachequesne/socket.io-msgpack-parser/releases/tag/3.0.1)
+- [socket.io-msgpack-parser@3.0.1](https://github.com/socketio/socket.io-msgpack-parser/releases/tag/3.0.1)
 
 More information about how to use those custom parsers can be found [here](https://github.com/socketio/socket.io/tree/master/examples/custom-parsers).
 

--- a/docs/categories/03-Client/client-installation.md
+++ b/docs/categories/03-Client/client-installation.md
@@ -112,7 +112,7 @@ There are several bundles available:
 |:------------------|:-----------------|:------------|
 | socket.io.js               | 34.7 kB gzip     | Unminified version, with [debug](https://www.npmjs.com/package/debug)    |
 | socket.io.min.js           | 14.7 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) |
-| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/darrachequesne/socket.io-msgpack-parser)    |
+| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/socketio/socket.io-msgpack-parser)    |
 
 The [debug](https://www.npmjs.com/package/debug) package allows to print debug information to the console. You can find more information [here](../01-Documentation/logging-and-debugging.md).
 

--- a/docs/categories/06-Advanced/custom-parser.md
+++ b/docs/categories/06-Advanced/custom-parser.md
@@ -137,7 +137,7 @@ Cons:
 
 This parser uses the [MessagePack](https://msgpack.org/) serialization format.
 
-The source code of this parser can be found here: https://github.com/darrachequesne/socket.io-msgpack-parser
+The source code of this parser can be found here: https://github.com/socketio/socket.io-msgpack-parser
 
 Sample usage:
 

--- a/docs/categories/07-Migrations/migrating-from-2-to-3.md
+++ b/docs/categories/07-Migrations/migrating-from-2-to-3.md
@@ -290,7 +290,7 @@ const io = require("socket.io")(httpServer, {
 });
 ```
 
-Please see [socket.io-msgpack-parser](https://github.com/darrachequesne/socket.io-msgpack-parser) for example.
+Please see [socket.io-msgpack-parser](https://github.com/socketio/socket.io-msgpack-parser) for example.
 
 
 #### Socket.join() and Socket.leave() are now synchronous
@@ -594,7 +594,7 @@ There are now 3 distinct bundles:
 |:------------------|:-----------------|:------------|
 | socket.io.js               | 34.7 kB gzip     | Unminified version, with [debug](https://www.npmjs.com/package/debug)    |
 | socket.io.min.js           | 14.7 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) |
-| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/darrachequesne/socket.io-msgpack-parser)    |
+| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/socketio/socket.io-msgpack-parser)    |
 
 By default, all of them are served by the server, at `/socket.io/<name>`.
 
@@ -770,7 +770,7 @@ socket.volatile.emit("volatile event", "might or might not be sent");
 
 #### Official bundle with the msgpack parser
 
-A bundle with the [socket.io-msgpack-parser](https://github.com/darrachequesne/socket.io-msgpack-parser) will now be provided (either on the CDN or served by the server at `/socket.io/socket.io.msgpack.min.js`).
+A bundle with the [socket.io-msgpack-parser](https://github.com/socketio/socket.io-msgpack-parser) will now be provided (either on the CDN or served by the server at `/socket.io/socket.io.msgpack.min.js`).
 
 Pros:
 

--- a/versioned_docs/version-3.x/categories/03-Client/client-installation.md
+++ b/versioned_docs/version-3.x/categories/03-Client/client-installation.md
@@ -114,7 +114,7 @@ There are several bundles available:
 |:------------------|:-----------------|:------------|
 | socket.io.js               | 34.7 kB gzip     | Unminified version, with [debug](https://www.npmjs.com/package/debug)    |
 | socket.io.min.js           | 14.7 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) |
-| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/darrachequesne/socket.io-msgpack-parser)    |
+| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/socketio/socket.io-msgpack-parser)    |
 
 The [debug](https://www.npmjs.com/package/debug) package allows to print debug information to the console. You can find more information [here](/docs/v3/logging-and-debugging/).
 

--- a/versioned_docs/version-3.x/categories/05-Advanced/custom-parser.md
+++ b/versioned_docs/version-3.x/categories/05-Advanced/custom-parser.md
@@ -137,7 +137,7 @@ Cons:
 
 This parser uses the [MessagePack](https://msgpack.org/) serialization format.
 
-The source code of this parser can be found here: https://github.com/darrachequesne/socket.io-msgpack-parser
+The source code of this parser can be found here: https://github.com/socketio/socket.io-msgpack-parser
 
 Sample usage:
 

--- a/versioned_docs/version-3.x/categories/06-Migrations/migrating-from-2-to-3.md
+++ b/versioned_docs/version-3.x/categories/06-Migrations/migrating-from-2-to-3.md
@@ -290,7 +290,7 @@ const io = require("socket.io")(httpServer, {
 });
 ```
 
-Please see [socket.io-msgpack-parser](https://github.com/darrachequesne/socket.io-msgpack-parser) for example.
+Please see [socket.io-msgpack-parser](https://github.com/socketio/socket.io-msgpack-parser) for example.
 
 
 ### Socket.join() and Socket.leave() are now synchronous
@@ -594,7 +594,7 @@ There are now 3 distinct bundles:
 |:------------------|:-----------------|:------------|
 | socket.io.js               | 34.7 kB gzip     | Unminified version, with [debug](https://www.npmjs.com/package/debug)    |
 | socket.io.min.js           | 14.7 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) |
-| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/darrachequesne/socket.io-msgpack-parser)    |
+| socket.io.msgpack.min.js   | 15.3 kB min+gzip | Production version, without [debug](https://www.npmjs.com/package/debug) and with the [msgpack parser](https://github.com/socketio/socket.io-msgpack-parser)    |
 
 By default, all of them are served by the server, at `/socket.io/<name>`.
 
@@ -770,7 +770,7 @@ socket.volatile.emit("volatile event", "might or might not be sent");
 
 ### Official bundle with the msgpack parser
 
-A bundle with the [socket.io-msgpack-parser](https://github.com/darrachequesne/socket.io-msgpack-parser) will now be provided (either on the CDN or served by the server at `/socket.io/socket.io.msgpack.min.js`).
+A bundle with the [socket.io-msgpack-parser](https://github.com/socketio/socket.io-msgpack-parser) will now be provided (either on the CDN or served by the server at `/socket.io/socket.io.msgpack.min.js`).
 
 Pros:
 


### PR DESCRIPTION
The links to the `socket.io-msgpack-parser` currently all use the old `https://github.com/darrachequesne/socket.io-msgpack-parser` URL, which now redirects to `https://github.com/socketio/socket.io-msgpack-parser`. This PR updates all references to the former to the latter.

When I was reading the custom parsers doc, when I first saw the link, my first thought was it was a "officially recognized third-party parser" as opposed to something that's first-party which I found on the clickthrough.