### PR TITLE
Update adapter-redis.md

### DIFF
--- a/docs/categories/05-Adapters/adapter-redis.md
+++ b/docs/categories/05-Adapters/adapter-redis.md
@@ -43,7 +43,7 @@ import { createClient } from "redis";
 
 const io = new Server();
 
-const pubClient = createClient({ url: 'redis://localhost:6379' });
+const pubClient = createClient({ url: "redis://localhost:6379" });
 const subClient = pubClient.duplicate();
 
 Promise.all([pubClient.connect(), subClient.connect()]).then(() => {
@@ -61,7 +61,7 @@ import { createClient } from "redis";
 
 const io = new Server();
 
-const pubClient = createClient({ url: 'redis://localhost:6379' });
+const pubClient = createClient({ url: "redis://localhost:6379" });
 const subClient = pubClient.duplicate();
 
 io.adapter(createAdapter(pubClient, subClient));
@@ -133,7 +133,7 @@ After:
 const { createClient } = require("redis");
 const { createAdapter } = require("@socket.io/redis-adapter");
 
-const pubClient = createClient({ url: 'redis://localhost:6379' });
+const pubClient = createClient({ url: "redis://localhost:6379" });
 const subClient = pubClient.duplicate();
 
 io.adapter(createAdapter(pubClient, subClient));
@@ -187,7 +187,7 @@ npm install @socket.io/redis-emitter redis
 import { Emitter } from "@socket.io/redis-emitter";
 import { createClient } from "redis";
 
-const redisClient = createClient({ url: 'redis://localhost:6379' });
+const redisClient = createClient({ url: "redis://localhost:6379" });
 
 redisClient.connect().then(() => {
   const emitter = new Emitter(redisClient);
@@ -204,7 +204,7 @@ Note: with `redis@3`, calling `connect()` on the Redis client is not needed:
 import { Emitter } from "@socket.io/redis-emitter";
 import { createClient } from "redis";
 
-const redisClient = createClient({ url: 'redis://localhost:6379' });
+const redisClient = createClient({ url: "redis://localhost:6379" });
 const emitter = new Emitter(redisClient);
 
 setInterval(() => {

--- a/docs/categories/05-Adapters/adapter-redis.md
+++ b/docs/categories/05-Adapters/adapter-redis.md
@@ -43,7 +43,7 @@ import { createClient } from "redis";
 
 const io = new Server();
 
-const pubClient = createClient({ host: "localhost", port: 6379 });
+const pubClient = createClient({ url: 'redis://localhost:6379' });
 const subClient = pubClient.duplicate();
 
 Promise.all([pubClient.connect(), subClient.connect()]).then(() => {
@@ -61,7 +61,7 @@ import { createClient } from "redis";
 
 const io = new Server();
 
-const pubClient = createClient({ host: "localhost", port: 6379 });
+const pubClient = createClient({ url: 'redis://localhost:6379' });
 const subClient = pubClient.duplicate();
 
 io.adapter(createAdapter(pubClient, subClient));
@@ -133,7 +133,7 @@ After:
 const { createClient } = require("redis");
 const { createAdapter } = require("@socket.io/redis-adapter");
 
-const pubClient = createClient({ host: "localhost", port: 6379 });
+const pubClient = createClient({ url: 'redis://localhost:6379' });
 const subClient = pubClient.duplicate();
 
 io.adapter(createAdapter(pubClient, subClient));
@@ -187,7 +187,7 @@ npm install @socket.io/redis-emitter redis
 import { Emitter } from "@socket.io/redis-emitter";
 import { createClient } from "redis";
 
-const redisClient = createClient({ host: "localhost", port: 6379 });
+const redisClient = createClient({ url: 'redis://localhost:6379' });
 
 redisClient.connect().then(() => {
   const emitter = new Emitter(redisClient);
@@ -204,7 +204,7 @@ Note: with `redis@3`, calling `connect()` on the Redis client is not needed:
 import { Emitter } from "@socket.io/redis-emitter";
 import { createClient } from "redis";
 
-const redisClient = createClient({ host: "localhost", port: 6379 });
+const redisClient = createClient({ url: 'redis://localhost:6379' });
 const emitter = new Emitter(redisClient);
 
 setInterval(() => {


### PR DESCRIPTION
Using host and port parameter wasn't working when I used something different from 127.0.0.1 and 6379. I checked the redis documentation, and it seems we have to use the url parameter like this redis://localhost:6379.