### PR TITLE
docs: add flag to show the last updated time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -159,6 +159,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
+          showLastUpdateTime: true,
           editUrl:
             "https://github.com/socketio/socket.io-website/edit/master/",
           lastVersion: "current",


### PR DESCRIPTION
Prior this PR, there was no way to tell if we were reading a new version of the page apart from reading it entirely.

Now we'll get something like this at the bottom:

![image](https://user-images.githubusercontent.com/13461315/150656533-83ab1410-05f9-447b-8c0f-bcc183f63091.png)