### PR TITLE
Fixed uWebSockets.js mentions

### DIFF
--- a/blog/2021-11-18-4.4.0.md
+++ b/blog/2021-11-18-4.4.0.md
@@ -12,9 +12,9 @@ We have just published a new minor version of Socket.IO: `4.4.0`
 
 After a big focus on the client in the [latest release](./2021-10-15-4.3.0.md), this release is more oriented towards the server.
 
-## Support for uWebSocket.js
+## Support for uWebSockets.js
 
-Why should one choose between performance and reliability? Starting with `socket.io@4.4.0`, you can now use the HTTP/WebSocket server provided by the [`uWebSocket.js`](https://github.com/uNetworking/uWebSockets.js) package:
+Why should one choose between performance and reliability? Starting with `socket.io@4.4.0`, you can now use the HTTP/WebSocket server provided by the [`uWebSockets.js`](https://github.com/uNetworking/uWebSockets.js) package:
 
 ```js
 const { App } = require("uWebSockets.js");

--- a/docs/categories/02-Server/server-installation.md
+++ b/docs/categories/02-Server/server-installation.md
@@ -163,7 +163,7 @@ This implementation "allows, but doesn't guarantee" significant performance and 
 
 ## Usage with `uWebSockets.js`
 
-Starting with version [4.4.0](/blog/socket-io-4-4-0/), a Socket.IO server can now bind to a `uWebSockets.js` server.
+Starting with version [4.4.0](/blog/socket-io-4-4-0/), a Socket.IO server can now bind to a [`uWebSockets.js`](https://github.com/uNetworking/uWebSockets.js) server.
 
 Installation:
 

--- a/docs/categories/02-Server/server-installation.md
+++ b/docs/categories/02-Server/server-installation.md
@@ -161,9 +161,9 @@ const io = new Server(3000, {
 
 This implementation "allows, but doesn't guarantee" significant performance and memory-usage improvements over the default implementation. As usual, please benchmark it against your own usage.
 
-## Usage with `uWebSocket.js`
+## Usage with `uWebSockets.js`
 
-Starting with version [4.4.0](/blog/socket-io-4-4-0/), a Socket.IO server can now bind to a `uWebSocket.js` server.
+Starting with version [4.4.0](/blog/socket-io-4-4-0/), a Socket.IO server can now bind to a `uWebSockets.js` server.
 
 Installation:
 


### PR DESCRIPTION
Docs https://socket.io/docs/v4/server-installation/ and blog https://socket.io/blog/socket-io-4-4-0/ are incorrectly referencing `uWebSockets.js` library as `uWebSocket.js`.

I didn't go as far as correcting the mentions to `µWebSockets.js` - which is actually the exact name of the project - just to keep consistency between code samples and text. But if anyone thinks it should be corrected to the exact name (and I am actually inclined to that) - I'll quickly update the changeset.