### PR TITLE
changed stated io(url) default values

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -69,14 +69,14 @@ You can find more information [here](https://github.com/socketio/socket.io-proto
 
 ### io([url][, options])
 
-  - `url` [`<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type) (defaults to `window.location`)
+  - `url` [`<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type) (defaults to `/socket.io`)
   - `options` [`<Object>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
     - `forceNew` [`<boolean>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#boolean_type) whether to create a new connection
   - **Returns** [`<Socket>`](#socket)
 
 Creates a new `Manager` for the given URL, and attempts to reuse an existing `Manager` for subsequent calls, unless the `multiplex` option is passed with `false`. Passing this option is the equivalent of passing `"force new connection": true` or `forceNew: true`.
 
-A new `Socket` instance is returned for the namespace specified by the pathname in the URL, defaulting to `/`. For example, if the `url` is `http://localhost/users`, a transport connection will be established to `http://localhost` and a Socket.IO connection will be established to `/users`.
+A new `Socket` instance is returned for the namespace specified by the pathname in the URL, defaulting to `/socket.io`. For example, if the `url` is `http://localhost/users`, a transport connection will be established to `http://localhost` and a Socket.IO connection will be established to `/users`.
 
 Query parameters can also be provided, either with the `query` option or directly in the url (example: `http://localhost/users?token=abc`).
 


### PR DESCRIPTION
Based on https://github.com/socketio/socket.io-client/blob/main/dist/socket.io.js#L3964 the default is neither `window.location` nor `/` but instead `/socket.io`