### PR TITLE
Simplify Caddyfile config

### DIFF
--- a/versioned_docs/version-3.x/categories/02-Server/behind-a-reverse-proxy.md
+++ b/versioned_docs/version-3.x/categories/02-Server/behind-a-reverse-proxy.md
@@ -111,13 +111,9 @@ Content of `Caddyfile` for [Caddy 2](https://caddyserver.com/v2)
 ```
 example.com {
   rewrite /path /path/
-  handle /path/* {
-    uri strip_prefix /path
+  handle_path /path/* {
     rewrite * /socket.io{path}
-    reverse_proxy localhost:3000 {
-      header_up Host {host}
-      header_up X-Real-IP {remote}
-    }
+    reverse_proxy localhost:3000
   }
 }
 ```


### PR DESCRIPTION
- The `handle_path` directive can be used to replace `handle` + `uri strip_prefix`: https://caddyserver.com/docs/caddyfile/directives/handle_path
- Setting those headers for `reverse_proxy` is unnecessary, Caddy already sets the appropriate headers automatically: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults