### PR TITLE
Fix link on `client-initialization.md`

### DIFF
--- a/versioned_docs/version-3.x/categories/03-Client/client-initialization.md
+++ b/versioned_docs/version-3.x/categories/03-Client/client-initialization.md
@@ -71,7 +71,7 @@ You can find more details about namespaces [here](/docs/v3/namespaces/).
 - [IO factory options](#IO-factory-options)
   - [forceNew](#forceNew)
   - [multiplex](#multiplex)
-- [Low-level engine options](#Low-level-engine-options)
+- [Low-level engine options](#low-level-engine-options)
   - [transports](#transports)
   - [upgrade](#upgrade)
   - [rememberUpgrade](#rememberUpgrade)


### PR DESCRIPTION
Fix link to `low-level-engine-options` section on `client-initialization.md`