### PR TITLE
Require `bcryptjs` instead of `bcrypt`

### DIFF
--- a/docs/categories/06-Advanced/admin-ui.md
+++ b/docs/categories/06-Advanced/admin-ui.md
@@ -132,7 +132,7 @@ Please note that the `bcrypt` package does not currently support hashes starting
 
 ```
 $ node
-> require("bcrypt").compareSync("<the password>", "<the hash>")
+> require("bcryptjs").compareSync("<the password>", "<the hash>")
 true
 ```
 
@@ -140,7 +140,7 @@ You can generate a valid hash with:
 
 ```
 $ node
-> require("bcrypt").hashSync("changeit", 10)
+> require("bcryptjs").hashSync("changeit", 10)
 '$2b$10$LQUE...'
 ```
 


### PR DESCRIPTION
Looks like that the module name is `bcryptjs`:
```js
> require("bcrypt").hashSync("changeit", 10)
Uncaught Error: Cannot find module 'bcrypt'
Require stack:
- <repl>
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:956:15)
    at Function.Module._load (node:internal/modules/cjs/loader:804:27)
    at Module.require (node:internal/modules/cjs/loader:1028:19)
    at require (node:internal/modules/cjs/helpers:102:18) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '<repl>' ]
}
> require("bcryptjs").hashSync("changeit", 10)
'$2a$10$t9LpTAKdKJvGsVXqNsHF5eOKkAVsGvZsDR0r2aCdNXRy1n007QM7q'
>
```