### PR TITLE
Further simplify caddyfile config

### DIFF
--- a/docs/categories/02-Server/behind-a-reverse-proxy.md
+++ b/docs/categories/02-Server/behind-a-reverse-proxy.md
@@ -171,7 +171,15 @@ httpProxy
 
 ## Caddy 2
 
-Content of `Caddyfile` for [Caddy 2](https://caddyserver.com/v2)
+Content of `Caddyfile` for [Caddy 2](https://caddyserver.com/v2), if you only want to forward the Socket.IO requests
+
+```
+example.com {
+    reverse_proxy /socket.io/* localhost:3000
+}
+```
+
+Or, if you want a custom path:
 
 ```
 example.com {
@@ -186,4 +194,5 @@ example.com {
 Related
 
 - [Solution forum post](https://caddy.community/t/i-cant-get-socket-io-proxy-to-work-on-v2/8703/2)
+- [Caddyfile reverse proxy](https://caddyserver.com/docs/caddyfile/patterns#reverse-proxy)
 - [Caddyfile directives](https://caddyserver.com/docs/caddyfile/directives)


### PR DESCRIPTION
Because https://github.com/socketio/socket.io/discussions/4379 is one of the top results when searching for "socket.io caddy", I think the documentation should reflect the most common case where only a reverse proxy is needed in addition to the more specific case where the path is changed, while still keeping the custom path linked for anyone who needs it.