### PR TITLE
Use `they` instead of `he/she` in the `chat.md` file

### DIFF
--- a/src/pages/get-started/chat.md
+++ b/src/pages/get-started/chat.md
@@ -310,7 +310,7 @@ Here are some ideas to improve the application:
 
 - Broadcast a message to connected users when someone connects or disconnects.
 - Add support for nicknames.
-- Don’t send the same message to the user that sent it. Instead, append the message directly as soon as he/she presses enter.
+- Don’t send the same message to the user that sent it. Instead, append the message directly as soon as they press enter.
 - Add “{user} is typing” functionality.
 - Show who’s online.
 - Add private messaging.


### PR DESCRIPTION
I genuinely don't see a reason (other than transphobic ones) to use `he/she` instead of `they`, hence why I'm making this PR