### PR TITLE
 docs: fix error message

### DIFF
--- a/docs/categories/04-Events/listening-to-events.md
+++ b/docs/categories/04-Events/listening-to-events.md
@@ -131,7 +131,7 @@ io.on("connection", (socket) => {
     const { error, value } = userSchema.validate(payload);
     if (error) {
       return callback({
-        status: "KO",
+        status: "Bad Request",
         error
       });
     }


### PR DESCRIPTION
The status 'KO' wasn't clear and relevant (at least to me), therefore I replaced it with a more relevant error message 'Bad Request'