### PR TITLE
docs: µWebSockets.js example initializes the server incorrectly

### DIFF
--- a/docs/categories/02-Server/server-initialization.md
+++ b/docs/categories/02-Server/server-initialization.md
@@ -596,7 +596,7 @@ server.listen(3000);
 import { App } from "uWebSockets.js";
 import { Server } from "socket.io";
 
-const app = new App();
+const app = App();
 const io = new Server();
 
 io.attachApp(app);


### PR DESCRIPTION
The uWebSockets.js docs say to initialize the server by just calling `App()` rather than attempting to use the constructor `new App()` as portrayed in the example on the SocketIO docs, which doesn't work. 

(In Typescript, you get an error: `Only a void function can be called with the 'new' keyword.`)