### PR TITLE
Update troubleshooting section with express-status-monitor conflict case

### DIFF
--- a/docs/categories/01-Documentation/troubleshooting.md
+++ b/docs/categories/01-Documentation/troubleshooting.md
@@ -369,6 +369,7 @@ io.on("connection", (socket) => {
 Possible explanations:
 
 - [a proxy in front of your servers does not accept the WebSocket connection](#a-proxy-in-front-of-your-servers-does-not-accept-the-WebSocket-connection)
+- you have [express-status-monitor](https://www.npmjs.com/package/express-status-monitor) library enabled that runs its own socket.io instance. Please see the solution [here](https://github.com/RafalWilinski/express-status-monitor) 
 
 ### A proxy in front of your servers does not accept the WebSocket connection
 


### PR DESCRIPTION
I faced the problem with **socket.io** and it's documentation didn't helped. So I spent some time to find the answer that my problem was a conflict between **express-status-monitor** and **socket.io** because status monitor also runs **socket.io** instance:

From their [github](https://github.com/RafalWilinski/express-status-monitor):
`If you're using socket.io in your project, this module could break your project because this module by default will spawn its own socket.io instance. To mitigate that, fill websocket parameter with your main socket.io instance as well as port parameter.`

So I think it will be helpful to add this case in the troubleshooting section.
I put a link on their GitHub repo where people can find a solution instead of writing the solution in docs just in case they will change something.