### PR TITLE
Fix fastify's deprecated server.listen()

### DIFF
--- a/docs/categories/02-Server/server-initialization.md
+++ b/docs/categories/02-Server/server-initialization.md
@@ -536,7 +536,7 @@ server.ready().then(() => {
   });
 });
 
-server.listen(3000);
+server.listen({ port: 3000 });
 ```
 
   </TabItem>
@@ -560,7 +560,7 @@ server.ready().then(() => {
   });
 });
 
-server.listen(3000);
+server.listen({ port: 3000 });
 ```
 
   </TabItem>
@@ -584,7 +584,7 @@ server.ready().then(() => {
   });
 });
 
-server.listen(3000);
+server.listen({ port: 3000 });
 ```
 
   </TabItem>


### PR DESCRIPTION
fastify.listen(MY_PORT) is deprecated since version 4.0.x. New way is to do is fastify.listen({ port: MY_PORT }).