### PR TITLE
Dark theme applied by default based on the user OS preference

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -223,6 +223,11 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Socket.IO`,
     },
+    colorMode: {
+      defaultMode: 'light',
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,


### PR DESCRIPTION
Bug: If a user applied dark theme in OS/Browser preference, when user lands for the first time, By default, LIGHT theme is applied.

Fix:
docusaurus have the config to apply theme based on the user's preference
REF: https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme


Screen capture after testing
[Screencast from 28-09-23 10_06_50 PM IST.webm](https://github.com/socketio/socket.io-website/assets/9389944/e24b97e1-854b-4349-9a7f-d640616a3d5c)
