### PR TITLE
docs: fix import in src/pages/how-to/use-with-react.md

### DIFF
--- a/src/pages/how-to/use-with-react.md
+++ b/src/pages/how-to/use-with-react.md
@@ -16,7 +16,7 @@ src
 ├── components
 │   ├── ConnectionManager.js
 │   ├── ConnectionState.js
-│   ├── MyEvents.js
+│   ├── Events.js
 │   └── MyForm.js
 └── socket.js
 ```
@@ -77,6 +77,7 @@ import React, { useState, useEffect } from 'react';
 import { socket } from './socket';
 import { ConnectionState } from './components/ConnectionState';
 import { ConnectionManager } from './components/ConnectionManager';
+import { Events } from "./components/Events";
 import { MyForm } from './components/MyForm';
 
 export default function App() {


### PR DESCRIPTION
This pull request corrects the directory structure presented in the example and amends the code to include the required import in the App.js illustration. I request the repository maintainers to review and merge it. Thanks.