### PR TITLE
Fix server-api.md sockets typo

### DIFF
--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -494,7 +494,7 @@ io.on("connection", (socket) => {
 
   socket.on("disconnect", async () => {
     const sockets = await io.in(userId).fetchSockets();
-    if (socket.length === 0) {
+    if (sockets.length === 0) {
       // no more active connections for the given user
     }
   });


### PR DESCRIPTION
Wrong "socket" variable name reference when checking active connections; it should be "sockets".