### PR TITLE
Update 07-api-overview.md

### DIFF
--- a/docs/tutorial/07-api-overview.md
+++ b/docs/tutorial/07-api-overview.md
@@ -206,7 +206,7 @@ The `emitWithAck()` method provides the same functionality, but returns a Promis
 
 ```js
 try {
-  const response = socket.timeout(5000).emitWithAck('request', { foo: 'bar' }, 'baz');
+  const response = await socket.timeout(5000).emitWithAck('request', { foo: 'bar' }, 'baz');
   console.log(response.status); // 'ok'
 } catch (e) {
   // the server did not acknowledge the event in the given delay


### PR DESCRIPTION
Add the await infront of promise callback, After that the response has print the respective status instead of undefined.