### PR TITLE
docs: add warning regarding using socket.data reference equality

### DIFF
--- a/docs/categories/02-Server/server-socket-instance.md
+++ b/docs/categories/02-Server/server-socket-instance.md
@@ -140,6 +140,39 @@ console.log(sockets[0].data.username); // "alice"
 
 More information [here](server-instance.md#utility-methods).
 
+:::caution
+Do not rely on reference equality when using properties of `data`.
+:::
+
+```js
+// BAD
+const activeUsers = new Set();
+io.on("connection", (socket) => {
+  socket.data.user = { name: "alice" };
+  activeUsers.add(socket.data.user);
+
+  socket.on("disconnect", () => {
+    // Socket.IO makes no guarentee data.user will reference the same object...
+    activeUsers.delete(socket.data.user);
+  });
+});
+```
+
+```js
+// GOOD
+const activeUsers = Map();
+io.on("connection", (socket) => {
+  const newUser = { name: "alice" };
+  socket.data.user = newUser;
+  activeUsers.set(socket.data.user.name, newUser);
+
+  socket.on("disconnect", () => {
+    // ... however primitive values will be preserved
+    activeUsers.delete(socket.data.user.name);
+  });
+});
+```
+
 ## Socket#conn
 
 A reference to the underlying Engine.IO socket (see [here](../01-Documentation/how-it-works.md)).


### PR DESCRIPTION
Related: https://github.com/socketio/socket.io/discussions/4935

This adds to the [Socket#data](https://socket.io/docs/v4/server-socket-instance/#socketdata), there are a few other places that mentioned socket.data

https://socket.io/docs/v4/server-instance/#fetchsockets
https://socket.io/docs/v4/server-api/#socketdata

So happy to move to either of these places.