### PR TITLE
Fixed links to examples to point to 'main' branch instead of 'master'

### DIFF
--- a/docs/categories/02-Server/using-multiple-nodes.md
+++ b/docs/categories/02-Server/using-multiple-nodes.md
@@ -138,7 +138,7 @@ Make sure you also configure `worker_processes` in the topmost level to indicate
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-nginx)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-nginx)
 - [NginX Documentation](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash)
 
 ### NginX Ingress (Kubernetes)
@@ -229,7 +229,7 @@ ProxyTimeout 60
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-httpd)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-httpd)
 - [Documentation](https://httpd.apache.org/docs/2.4/en/mod/mod_proxy.html#proxypass)
 
 ### HAProxy configuration
@@ -252,7 +252,7 @@ backend nodes
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-haproxy)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-haproxy)
 - [Documentation](http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#cookie)
 
 ### Traefik
@@ -294,7 +294,7 @@ http:
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-traefik)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-traefik)
 - [Documentation](https://doc.traefik.io/traefik/v2.0/routing/services/#sticky-sessions)
 
 ### Using Node.js Cluster

--- a/i18n/fr/docusaurus-plugin-content-docs/current/categories/02-Server/using-multiple-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/categories/02-Server/using-multiple-nodes.md
@@ -128,7 +128,7 @@ Make sure you also configure `worker_processes` in the topmost level to indicate
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-nginx)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-nginx)
 - [NginX Documentation](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash)
 
 ### Apache HTTPD configuration {#apache-httpd-configuration}
@@ -161,7 +161,7 @@ ProxyTimeout 3
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-httpd)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-httpd)
 - [Documentation](https://httpd.apache.org/docs/2.4/en/mod/mod_proxy.html#proxypass)
 
 ### HAProxy configuration {#haproxy-configuration}
@@ -184,7 +184,7 @@ backend nodes
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-haproxy)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-haproxy)
 - [Documentation](http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#cookie)
 
 ### Traefik {#traefik}
@@ -226,7 +226,7 @@ http:
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-traefik)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-traefik)
 - [Documentation](https://doc.traefik.io/traefik/v2.0/routing/services/#sticky-sessions)
 
 ### Using Node.js Cluster {#using-nodejs-cluster}

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/categories/02-Server/using-multiple-nodes.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/categories/02-Server/using-multiple-nodes.md
@@ -128,7 +128,7 @@ Make sure you also configure `worker_processes` in the topmost level to indicate
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-nginx)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-nginx)
 - [NginX Documentation](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash)
 
 ### Apache HTTPD configuration {#apache-httpd-configuration}
@@ -161,7 +161,7 @@ ProxyTimeout 3
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-httpd)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-httpd)
 - [Documentation](https://httpd.apache.org/docs/2.4/en/mod/mod_proxy.html#proxypass)
 
 ### HAProxy configuration {#haproxy-configuration}
@@ -184,7 +184,7 @@ backend nodes
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-haproxy)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-haproxy)
 - [Documentation](http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#cookie)
 
 ### Traefik {#traefik}
@@ -226,7 +226,7 @@ http:
 
 Links:
 
-- [Example](https://github.com/socketio/socket.io/tree/master/examples/cluster-traefik)
+- [Example](https://github.com/socketio/socket.io/tree/main/examples/cluster-traefik)
 - [Documentation](https://doc.traefik.io/traefik/v2.0/routing/services/#sticky-sessions)
 
 ### Using Node.js Cluster {#using-nodejs-cluster}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/02-Server/middlewares.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/02-Server/middlewares.md
@@ -176,4 +176,4 @@ io.use((socket, next) => {
 });
 ```
 
-可以在[此处](https://github.com/socketio/socket.io/tree/master/examples/passport-example)找到 Passport 的完整示例。
+可以在[此处](https://github.com/socketio/socket.io/tree/main/examples/passport-example)找到 Passport 的完整示例。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/02-Server/using-multiple-nodes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/02-Server/using-multiple-nodes.md
@@ -128,7 +128,7 @@ http {
 
 链接：
 
-- [例子](https://github.com/socketio/socket.io/tree/master/examples/cluster-nginx)
+- [例子](https://github.com/socketio/socket.io/tree/main/examples/cluster-nginx)
 - [NginX 文档](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash)
 
 ### Apache HTTPD 配置 {#apache-httpd-configuration}
@@ -161,7 +161,7 @@ ProxyTimeout 3
 
 链接：
 
-- [例子](https://github.com/socketio/socket.io/tree/master/examples/cluster-httpd)
+- [例子](https://github.com/socketio/socket.io/tree/main/examples/cluster-httpd)
 - [文档](https://httpd.apache.org/docs/2.4/en/mod/mod_proxy.html#proxypass)
 
 ### HAProxy 配置 {#haproxy-configuration}
@@ -184,7 +184,7 @@ backend nodes
 
 链接：
 
-- [例子](https://github.com/socketio/socket.io/tree/master/examples/cluster-haproxy)
+- [例子](https://github.com/socketio/socket.io/tree/main/examples/cluster-haproxy)
 - [文档](http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#cookie)
 
 ### Traefik {#traefik}
@@ -226,7 +226,7 @@ http:
 
 链接：
 
-- [例子](https://github.com/socketio/socket.io/tree/master/examples/cluster-traefik)
+- [例子](https://github.com/socketio/socket.io/tree/main/examples/cluster-traefik)
 - [文档](https://doc.traefik.io/traefik/v2.0/routing/services/#sticky-sessions)
 
 ### 使用 Node.js 集群 {#using-nodejs-cluster}

--- a/src/pages/demos/chat.md
+++ b/src/pages/demos/chat.md
@@ -18,7 +18,7 @@ title: Chat
     https://socketio-chat-h9jt.herokuapp.com/
   </a>
   <a
-    href="https://github.com/socketio/socket.io/tree/master/examples/chat"
+    href="https://github.com/socketio/socket.io/tree/main/examples/chat"
     style={{ float: "right", fontSize: 12 }}
   >
     View source code

--- a/src/pages/demos/whiteboard.md
+++ b/src/pages/demos/whiteboard.md
@@ -18,7 +18,7 @@ title: Whiteboard
     https://socketio-whiteboard-zmx4.herokuapp.com/
   </a>
   <a
-    href="https://github.com/socketio/socket.io/tree/master/examples/whiteboard"
+    href="https://github.com/socketio/socket.io/tree/main/examples/whiteboard"
     style={{ float: "right", fontSize: 12 }}
   >
     View source code


### PR DESCRIPTION
I found that the examples' links point to the 'master' branch. Instead, they should target the 'main' branch. 