### PR TITLE
Fix: #418 sponsor logos not visible in dark mode

### DIFF
--- a/sponsors.json
+++ b/sponsors.json
@@ -171,12 +171,12 @@
   },
   {
     "url": "https://leafletcasino.com/",
-    "img": "https://images.opencollective.com/leafletcasino-com/f8cd951/logo.png",
+    "img": "https://images.opencollective.com/leafletcasino-com/f8cd951/logo.jpg",
     "alt": "leafletcasino.com"
   },
   {
     "url": "https://www.automatenspiele.org/",
-    "img": "https://images.opencollective.com/guest-f6c2cab7/3a3f6a4/avatar.png",
+    "img": "https://images.opencollective.com/guest-f6c2cab7/3a3f6a4/avatar.jpg",
     "alt": "automatenspiele.org"
   },
   {
@@ -206,7 +206,7 @@
   },
   {
     "url": "https://www.5bingosites.com",
-    "img": "https://images.opencollective.com/www-5bingosites-com/3ffb7e5/logo.png",
+    "img": "https://images.opencollective.com/www-5bingosites-com/3ffb7e5/logo.jpg",
     "alt": "www.5bingosites.com"
   },
   {
@@ -246,22 +246,22 @@
   },
   {
     "url": "http://www.australiainternetpokies.com/",
-    "img": "https://images.opencollective.com/au-internet-pokies/72c3d0e/logo.png",
+    "img": "https://images.opencollective.com/au-internet-pokies/72c3d0e/logo.jpg",
     "alt": "AU Internet Pokies"
   },
   {
     "url": "https://www.australiaonlinecasinosites.com/",
-    "img": "https://images.opencollective.com/au-online-casinos/c0c9091/logo.png",
+    "img": "https://images.opencollective.com/au-online-casinos/c0c9091/logo.jpg",
     "alt": "AU Online Casinos"
   },
   {
     "url": "https://www.casinoaus.net/",
-    "img": "https://images.opencollective.com/casinoaus/402ed7b/logo.png",
+    "img": "https://images.opencollective.com/casinoaus/402ed7b/logo.jpg",
     "alt": "CasinoAus"
   },
   {
     "url": "https://www.topaustraliangambling.com/",
-    "img": "https://images.opencollective.com/top-australian-gambling/e6df914/logo.png",
+    "img": "https://images.opencollective.com/top-australian-gambling/e6df914/logo.jpg",
     "alt": "Top Australian Gambling"
   },
   {
@@ -401,7 +401,7 @@
   },
   {
     "url": "https://releaf.co.uk",
-    "img": "https://images.opencollective.com/releaf/b1db8e6/logo.png",
+    "img": "https://images.opencollective.com/releaf/b1db8e6/logo.jpg",
     "alt": "Releaf"
   },
   {
@@ -441,7 +441,7 @@
   },
   {
     "url": "https://www.easeus.de/",
-    "img": "https://images.opencollective.com/easeus-sofware-german/1fb5fa1/logo.png",
+    "img": "https://images.opencollective.com/easeus-sofware-german/1fb5fa1/logo.jpg",
     "alt": "EaseUS Germany"
   },
   {
@@ -521,7 +521,7 @@
   },
   {
     "url": "https://www.bogdancazino.ro/",
-    "img": "https://images.opencollective.com/bogdancazino/9327bba/avatar.png",
+    "img": "https://images.opencollective.com/bogdancazino/9327bba/avatar.jpg",
     "alt": "Bogdancazino"
   },
   {


### PR DESCRIPTION
Used jpg logos for the following sponsors:

Leaflet Casino,
Automatenspiele,
5bingosites,
Australia Internet Pokies,
Australia Online Casino Sites,
Casino Aus,
Top Australian Gambling,
Releaf,
Easeus,
Bogdancazino