### PR TITLE
Cluster package install fix

### DIFF
--- a/docs/tutorial/12-scaling-horizontally.md
+++ b/docs/tutorial/12-scaling-horizontally.md
@@ -38,7 +38,7 @@ So let's install the cluster adapter:
   <TabItem value="npm" label="NPM" default>
 
 ```sh
-npm install @socket.io/cluster-adapter
+npm install '@socket.io/cluster-adapter'
 ```
 
   </TabItem>


### PR DESCRIPTION
 Trying to run an npm install command in a PowerShell environment, but PowerShell is interpreting the @ symbol as a splatting operator, which is causing the error. To avoid this, we can use quotes around the package name.
--> npm install '@socket.io/cluster-adapter'