### PR TITLE
Update broken link in the [Introducing Socket.IO 1.0] blog section

### DIFF
--- a/blog/2014-05-28-1.0.0.md
+++ b/blog/2014-05-28-1.0.0.md
@@ -14,16 +14,16 @@ Socket.IO has thus become the `EventEmitter` of the web. Today I want to talk ab
 
 There's a lot to say about Socket.IO 1.0, so if you're short in time, feel free to jump to the parts that are most interesting to you:
 
-1. [New engine](#New-engine)
-2. [Binary support](#Binary-support)
-3. [Automated testing](#Automated-Testing)
-4. [Scalability](#Scalability)
-5. [Integration](#Integration)
-6. [Better debugging](#Better-debugging)
-7. [Streamlined APIs](#Streamlined-APIs)
-8. [CDN delivery](#CDN-delivery)
-9. [Future innovation](#Future-innovation)
-10. [Credits](#Credits)
+1. [New engine](#new-engine)
+2. [Binary support](#binary-support)
+3. [Automated testing](#automated-Testing)
+4. [Scalability](#scalability)
+5. [Integration](#integration)
+6. [Better debugging](#better-debugging)
+7. [Streamlined APIs](#streamlined-apis)
+8. [CDN delivery](#cdn-delivery)
+9. [Future innovation](#future-innovation)
+10. [Credits](#credits)
 
 
 ## New engine


### PR DESCRIPTION
The previous links do not lead to the appropriate sections within the document.  I updated the links to quickly jump the reader to the section to read without scrolling to the section.