### PR TITLE
Update connection-state-recovery.md

### DIFF
--- a/docs/categories/01-Documentation/connection-state-recovery.md
+++ b/docs/categories/01-Documentation/connection-state-recovery.md
@@ -22,6 +22,11 @@ This feature will help you cope with such disconnections, but unless you want to
 
 That's why you will still need to handle the case where the states of the client and the server must be synchronized.
 
+:::tip
+
+Connection State Recovery will NOT be successful unless the client has received *at least* one event from the server
+
+:::
 ## Usage
 
 Connection state recovery must be enabled by the server:


### PR DESCRIPTION
Added an additional warning regarding the fact that the server must emit one event to client in order for connection state recovery to be successful