### PR TITLE
chore: Add server Golang new repository since original one has been archived

### DIFF
--- a/docs/categories/01-Documentation/index.md
+++ b/docs/categories/01-Documentation/index.md
@@ -47,7 +47,8 @@ You can find more detail about that in the ["How it works" section](./how-it-wor
 | Java                 | https://github.com/mrniko/netty-socketio                                                                                                                |
 | Java                 | https://github.com/trinopoty/socket.io-server-java                                                                                                      |
 | Python               | https://github.com/miguelgrinberg/python-socketio                                                                                                       |
-| Golang               | https://github.com/googollee/go-socket.io                                                                                                               |
+| Golang               | https://github.com/googollee/go-socket.io (repository archived)                                                                                         |
+| Golang               | https://github.com/feederco/go-socket.io                                                                                                                |
 | Rust                 | https://github.com/Totodore/socketioxide                                                                                                                |
 
 ### Client implementations


### PR DESCRIPTION
Add new repository link

![image](https://github.com/user-attachments/assets/358fc8d8-6be1-47a3-9e7b-d53bbfa4cf07)


 mentioned googollee/go-socket.io#643