### PR TITLE
docs edit console.log on express startup to match the image

### DIFF
--- a/docs/tutorial/02-project-initialization.md
+++ b/docs/tutorial/02-project-initialization.md
@@ -71,7 +71,7 @@ app.get('/', (req, res) => {
 });
 
 server.listen(3000, () => {
-  console.log('server running at http://localhost:3000');
+  console.log('listening on http://localhost:3000');
 });
 ```
 
@@ -90,7 +90,7 @@ app.get('/', (req, res) => {
 });
 
 server.listen(3000, () => {
-  console.log('server running at http://localhost:3000');
+  console.log('listening on http://localhost:3000');
 });
 ```
 


### PR DESCRIPTION
**Problem**
- The code sample logs `server running at http://localhost:3000` to the console
- The screenshot below shows a different output in the terminal
- This may cause some confusion to the inexperienced who may be setting up a node server for the first time

<img width="922" alt="image" src="https://github.com/user-attachments/assets/843df795-a43f-4d50-8f7e-9270d16dfc3f" />

**Solution**
- I have updated the code snippet to match the screenshot