### PR TITLE
docs: add bun install as a server install option

### DIFF
--- a/docs/categories/02-Server/server-installation.md
+++ b/docs/categories/02-Server/server-installation.md
@@ -52,6 +52,13 @@ pnpm add socket.io
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io
+```
+
+  </TabItem>
 </Tabs>
 
 To install a specific version:
@@ -75,6 +82,13 @@ yarn add socket.io@version
 
 ```sh
 pnpm add socket.io@version
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io@version
 ```
 
   </TabItem>
@@ -113,6 +127,13 @@ pnpm add -O bufferutil utf-8-validate
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add --optional bufferutil utf-8-validate
+```
+
+  </TabItem>
 </Tabs>
 
 Please note that these packages are optional, the WebSocket server will fallback to the Javascript implementation if they are not available. More information can be found [here](https://github.com/websockets/ws/#opt-in-for-performance-and-spec-compliance).
@@ -142,6 +163,13 @@ yarn add eiows
 
 ```sh
 pnpm add eiows
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add eiows
 ```
 
   </TabItem>
@@ -185,6 +213,13 @@ yarn add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 
 ```sh
 pnpm add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 ```
 
   </TabItem>

--- a/docs/categories/03-Client/client-installation.md
+++ b/docs/categories/03-Client/client-installation.md
@@ -155,6 +155,13 @@ pnpm add socket.io-client
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io-client
+```
+
+  </TabItem>
 </Tabs>
 
 The client can also be run from Node.js.

--- a/docs/tutorial/10-server-delivery.md
+++ b/docs/tutorial/10-server-delivery.md
@@ -48,6 +48,13 @@ pnpm add sqlite sqlite3
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add sqlite sqlite3
+```
+
+  </TabItem>
 </Tabs>
 
 We will simply store each message in a SQL table:

--- a/docs/tutorial/12-scaling-horizontally.md
+++ b/docs/tutorial/12-scaling-horizontally.md
@@ -56,6 +56,13 @@ pnpm add @socket.io/cluster-adapter
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add @socket.io/cluster-adapter
+```
+
+  </TabItem>
 </Tabs>
 
 Now we plug it in:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/categories/02-Server/server-installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/categories/02-Server/server-installation.md
@@ -44,6 +44,13 @@ pnpm add socket.io
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io
+```
+
+  </TabItem>
 </Tabs>
 
 To install a specific version:
@@ -67,6 +74,13 @@ yarn add socket.io@version
 
 ```sh
 pnpm add socket.io@version
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io@version
 ```
 
   </TabItem>
@@ -114,6 +128,13 @@ pnpm add -O bufferutil utf-8-validate
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add --optional bufferutil utf-8-validate
+```
+
+  </TabItem>
 </Tabs>
 
 Please note that these packages are optional, the WebSocket server will fallback to the Javascript implementation if they are not available. More information can be found [here](https://github.com/websockets/ws/#opt-in-for-performance-and-spec-compliance).
@@ -143,6 +164,13 @@ yarn add eiows
 
 ```sh
 pnpm add eiows
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add eiows
 ```
 
   </TabItem>
@@ -186,6 +214,13 @@ yarn add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 
 ```sh
 pnpm add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 ```
 
   </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/categories/03-Client/client-installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/categories/03-Client/client-installation.md
@@ -156,6 +156,13 @@ pnpm add socket.io-client
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io-client
+```
+
+  </TabItem>
 </Tabs>
 
 The client can also be run from Node.js.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/10-server-delivery.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/10-server-delivery.md
@@ -48,6 +48,13 @@ pnpm add sqlite sqlite3
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add sqlite sqlite3
+```
+
+  </TabItem>
 </Tabs>
 
 We will simply store each message in a SQL table:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/12-scaling-horizontally.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/12-scaling-horizontally.md
@@ -56,6 +56,13 @@ pnpm add @socket.io/cluster-adapter
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add @socket.io/cluster-adapter
+```
+
+  </TabItem>
 </Tabs>
 
 Now we plug it in:

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/categories/02-Server/server-installation.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/categories/02-Server/server-installation.md
@@ -44,6 +44,13 @@ pnpm add socket.io
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io
+```
+
+  </TabItem>
 </Tabs>
 
 To install a specific version:
@@ -67,6 +74,13 @@ yarn add socket.io@version
 
 ```sh
 pnpm add socket.io@version
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io@version
 ```
 
   </TabItem>
@@ -114,6 +128,13 @@ pnpm add -O bufferutil utf-8-validate
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add --optional bufferutil utf-8-validate
+```
+
+  </TabItem>
 </Tabs>
 
 Please note that these packages are optional, the WebSocket server will fallback to the Javascript implementation if they are not available. More information can be found [here](https://github.com/websockets/ws/#opt-in-for-performance-and-spec-compliance).
@@ -143,6 +164,13 @@ yarn add eiows
 
 ```sh
 pnpm add eiows
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add eiows
 ```
 
   </TabItem>
@@ -186,6 +214,13 @@ yarn add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 
 ```sh
 pnpm add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 ```
 
   </TabItem>

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/categories/03-Client/client-installation.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/categories/03-Client/client-installation.md
@@ -156,6 +156,13 @@ pnpm add socket.io-client
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io-client
+```
+
+  </TabItem>
 </Tabs>
 
 The client can also be run from Node.js.

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/tutorial/10-server-delivery.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/tutorial/10-server-delivery.md
@@ -48,6 +48,13 @@ pnpm add sqlite sqlite3
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add sqlite sqlite3
+```
+
+  </TabItem>
 </Tabs>
 
 We will simply store each message in a SQL table:

--- a/i18n/pt-br/docusaurus-plugin-content-docs/current/tutorial/12-scaling-horizontally.md
+++ b/i18n/pt-br/docusaurus-plugin-content-docs/current/tutorial/12-scaling-horizontally.md
@@ -56,6 +56,13 @@ pnpm add @socket.io/cluster-adapter
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add @socket.io/cluster-adapter
+```
+
+  </TabItem>
 </Tabs>
 
 Now we plug it in:

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/02-Server/server-installation.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/02-Server/server-installation.md
@@ -44,6 +44,13 @@ pnpm add socket.io
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io
+```
+
+  </TabItem>
 </Tabs>
 
 安装特定版本：
@@ -67,6 +74,13 @@ yarn add socket.io@version
 
 ```sh
 pnpm add socket.io@version
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io@version
 ```
 
   </TabItem>
@@ -114,6 +128,13 @@ pnpm add -O bufferutil utf-8-validate
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add --optional bufferutil utf-8-validate
+```
+
+  </TabItem>
 </Tabs>
 
 请注意，这些包是可选的，如果它们不可用，WebSocket 服务器将回退到 Javascript 实现。更多信息可以在[这里](https://github.com/websockets/ws/#opt-in-for-performance-and-spec-compliance)找到。
@@ -146,6 +167,13 @@ pnpm add eiows
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add eiows
+```
+
+  </TabItem>
 </Tabs>
 
 然后使用`wsEngine`选项：
@@ -159,7 +187,7 @@ const io = new Server(3000, {
 });
 ```
 
-与默认实现相比，此实现“允许但不保证”显着的性能和内存使用改进。像往常一样，请根据您自己的使用情况对其进行基准测试。
+与默认实现相比，此实现"允许但不保证"显着的性能和内存使用改进。像往常一样，请根据您自己的使用情况对其进行基准测试。
 
 ## 使用 `µWebSockets.js` {#usage-with-µwebsocketsjs}
 
@@ -186,6 +214,13 @@ yarn add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 
 ```sh
 pnpm add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
+```
+
+  </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add uWebSockets.js@uNetworking/uWebSockets.js#v20.4.0
 ```
 
   </TabItem>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/03-Client/client-installation.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/categories/03-Client/client-installation.md
@@ -157,6 +157,13 @@ pnpm add socket.io-client
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add socket.io-client
+```
+
+  </TabItem>
 </Tabs>
 
 客户端也可以从 Node.js 运行。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/10-server-delivery.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/10-server-delivery.md
@@ -48,6 +48,13 @@ pnpm add sqlite sqlite3
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add sqlite sqlite3
+```
+
+  </TabItem>
 </Tabs>
 
 We will simply store each message in a SQL table:

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/12-scaling-horizontally.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/12-scaling-horizontally.md
@@ -56,6 +56,13 @@ pnpm add @socket.io/cluster-adapter
 ```
 
   </TabItem>
+  <TabItem value="bun" label="Bun">
+
+```sh
+bun add @socket.io/cluster-adapter
+```
+
+  </TabItem>
 </Tabs>
 
 Now we plug it in:


### PR DESCRIPTION
Adds bun as an option alongside npm/yarn/pnpm as a way to install socket.io on the server.

Here's a screenshot:
<img width="337" alt="Screenshot_2025-03-06_at_2 38 51_PM" src="https://github.com/user-attachments/assets/b4b7dc6a-a61b-4e5b-8570-7ce4ec21f8ab" />
