### PR TITLE
Update url to golang server repo

### DIFF
--- a/docs/categories/01-Documentation/index.md
+++ b/docs/categories/01-Documentation/index.md
@@ -47,7 +47,7 @@ You can find more detail about that in the ["How it works" section](./how-it-wor
 | Java                 | https://github.com/mrniko/netty-socketio                                                                                                                |
 | Java                 | https://github.com/trinopoty/socket.io-server-java                                                                                                      |
 | Python               | https://github.com/miguelgrinberg/python-socketio                                                                                                       |
-| Golang               | https://github.com/googollee/go-socket.io                                                                                                               |
+| Golang               | https://github.com/feederco/go-socket.io                                                                                                                |
 | Rust                 | https://github.com/Totodore/socketioxide                                                                                                                |
 
 ### Client implementations


### PR DESCRIPTION
This change was made as the original repository is no longer maintained.