### PR TITLE
feat: Add alternative Golang server implementation

### DIFF
--- a/docs/categories/01-Documentation/index.md
+++ b/docs/categories/01-Documentation/index.md
@@ -48,7 +48,8 @@ You can find more details about that in the ["How it works" section](./how-it-wo
 | Java                 | https://github.com/mrniko/netty-socketio                                                                                                                |
 | Java                 | https://github.com/trinopoty/socket.io-server-java                                                                                                      |
 | Python               | https://github.com/miguelgrinberg/python-socketio                                                                                                       |
-| Golang               | https://github.com/googollee/go-socket.io                                                                                                               |
+| Golang (ARCHIVED)    | https://github.com/googollee/go-socket.io                                                                                                               |
+| Golang               | https://github.com/arcaela/socket.io-client-go                                                                                                          |
 | Rust                 | https://github.com/Totodore/socketioxide                                                                                                                |
 
 ### Client implementations


### PR DESCRIPTION
This PR adds [`arcaela/socket.io-client-go`](https://github.com/arcaela/socket.io-client-go) as an alternative Golang entry in the **Server implementations** table.

The currently listed repository (`googollee/go-socket.io`) has been archived and is no longer maintained. This implementation offers a fully tested, actively maintained option with Engine.IO v4 and Socket.IO v5 support, along with official documentation aligned to Socket.IO standards.

Related: #487, #491