### PR TITLE
remove unmaintained fastify plugin

### DIFF
--- a/docs/categories/02-Server/server-initialization.md
+++ b/docs/categories/02-Server/server-initialization.md
@@ -513,82 +513,62 @@ NestJS v7 and below relies on Socket.IO v2, while NestJS v8 relies on Socket.IO 
 
 ### With Fastify
 
-You need to register the [`fastify-socket.io`](https://github.com/alemagio/fastify-socket.io) plugin:
-
 <Tabs groupId="lang">
   <TabItem value="cjs" label="CommonJS" default>
 
 ```js
-const fastify = require("fastify");
-const fastifyIO = require("fastify-socket.io");
+const { Server } = require("socket.io");
 
-const server = fastify();
-server.register(fastifyIO);
+const fastify = require('fastify')();
+const io = new Server(fastify.server, { /* options */ });
 
-server.get("/", (req, reply) => {
-  server.io.emit("hello");
+io.on("connection", (socket) => {
+  // ...
 });
 
-server.ready().then(() => {
-  // we need to wait for the server to be ready, else `server.io` is undefined
-  server.io.on("connection", (socket) => {
-    // ...
-  });
-});
-
-server.listen({ port: 3000 });
+fastify.listen({ port: 3000 });
 ```
 
   </TabItem>
   <TabItem value="mjs" label="ES modules">
 
 ```js
-import fastify from "fastify";
-import fastifyIO from "fastify-socket.io";
+import Fastify from 'fastify';
+import { Server } from "socket.io";
+const { Server } = require("socket.io");
 
-const server = fastify();
-server.register(fastifyIO);
+const fastify = Fastify();
+const io = new Server(fastify.server, { /* options */ });
 
-server.get("/", (req, reply) => {
-  server.io.emit("hello");
+io.on("connection", (socket) => {
+  // ...
 });
 
-server.ready().then(() => {
-  // we need to wait for the server to be ready, else `server.io` is undefined
-  server.io.on("connection", (socket) => {
-    // ...
-  });
-});
-
-server.listen({ port: 3000 });
+fastify.listen({ port: 3000 });
 ```
 
   </TabItem>
   <TabItem value="ts" label="TypeScript">
 
 ```ts
-import fastify from "fastify";
-import fastifyIO from "fastify-socket.io";
+import Fastify from 'fastify';
+import { Server } from "socket.io";
+const { Server } = require("socket.io");
 
-const server = fastify();
-server.register(fastifyIO);
+const fastify = Fastify();
+const io = new Server(fastify.server, { /* options */ });
 
-server.get("/", (req, reply) => {
-  server.io.emit("hello");
+io.on("connection", (socket) => {
+  // ...
 });
 
-server.ready().then(() => {
-  // we need to wait for the server to be ready, else `server.io` is undefined
-  server.io.on("connection", (socket) => {
-    // ...
-  });
-});
-
-server.listen({ port: 3000 });
+fastify.listen({ port: 3000 });
 ```
 
   </TabItem>
 </Tabs>
+
+More information [here](https://fastify.dev/).
 
 ### With µWebSockets.js {#with-uwebsocketsjs}
 

--- a/docs/categories/02-Server/server-initialization.md
+++ b/docs/categories/02-Server/server-initialization.md
@@ -526,6 +526,15 @@ io.on("connection", (socket) => {
   // ...
 });
 
+app.addHook('preClose', done => {
+  io.local.disconnectSockets(true);
+  done();
+});
+
+app.addHook('onClose', (_instance, done) => {
+  io.close(done);
+});
+
 fastify.listen({ port: 3000 });
 ```
 
@@ -544,6 +553,15 @@ io.on("connection", (socket) => {
   // ...
 });
 
+app.addHook('preClose', done => {
+  io.local.disconnectSockets(true);
+  done();
+});
+
+app.addHook('onClose', (_instance, done) => {
+  io.close(done);
+});
+
 fastify.listen({ port: 3000 });
 ```
 
@@ -560,6 +578,15 @@ const io = new Server(fastify.server, { /* options */ });
 
 io.on("connection", (socket) => {
   // ...
+});
+
+app.addHook('preClose', done => {
+  io.local.disconnectSockets(true);
+  done();
+});
+
+app.addHook('onClose', (_instance, done) => {
+  io.close(done);
 });
 
 fastify.listen({ port: 3000 });

--- a/docs/categories/02-Server/server-initialization.md
+++ b/docs/categories/02-Server/server-initialization.md
@@ -517,21 +517,23 @@ NestJS v7 and below relies on Socket.IO v2, while NestJS v8 relies on Socket.IO 
   <TabItem value="cjs" label="CommonJS" default>
 
 ```js
+const Fastify = require("fastify");
 const { Server } = require("socket.io");
 
-const fastify = require('fastify')();
+const fastify = Fastify();
 const io = new Server(fastify.server, { /* options */ });
 
 io.on("connection", (socket) => {
   // ...
 });
 
-app.addHook('preClose', done => {
+app.addHook("preClose", (done) => {
+  // close all active connections on this server
   io.local.disconnectSockets(true);
   done();
 });
 
-app.addHook('onClose', (_instance, done) => {
+app.addHook("onClose", (_instance, done) => {
   io.close(done);
 });
 
@@ -542,9 +544,8 @@ fastify.listen({ port: 3000 });
   <TabItem value="mjs" label="ES modules">
 
 ```js
-import Fastify from 'fastify';
+import Fastify from "fastify";
 import { Server } from "socket.io";
-const { Server } = require("socket.io");
 
 const fastify = Fastify();
 const io = new Server(fastify.server, { /* options */ });
@@ -553,12 +554,13 @@ io.on("connection", (socket) => {
   // ...
 });
 
-app.addHook('preClose', done => {
+app.addHook("preClose", (done) => {
+  // close all active connections on this server
   io.local.disconnectSockets(true);
   done();
 });
 
-app.addHook('onClose', (_instance, done) => {
+app.addHook("onClose", (_instance, done) => {
   io.close(done);
 });
 
@@ -569,9 +571,8 @@ fastify.listen({ port: 3000 });
   <TabItem value="ts" label="TypeScript">
 
 ```ts
-import Fastify from 'fastify';
+import Fastify from "fastify";
 import { Server } from "socket.io";
-const { Server } = require("socket.io");
 
 const fastify = Fastify();
 const io = new Server(fastify.server, { /* options */ });
@@ -580,12 +581,13 @@ io.on("connection", (socket) => {
   // ...
 });
 
-app.addHook('preClose', done => {
+app.addHook("preClose", (done) => {
+  // close all active connections on this server
   io.local.disconnectSockets(true);
   done();
 });
 
-app.addHook('onClose', (_instance, done) => {
+app.addHook("onClose", (_instance, done) => {
   io.close(done);
 });
 


### PR DESCRIPTION
The [fastify-socket.io](https://github.com/alemagio/fastify-socket.io) plugin is unmaintained and does not work with the latest version of Fastify.
It's actually very easy to initialize socket.io with Fastify without a plugin, as you can access the Node core server object used by it with `fastify.server`.