### PR TITLE
docs: clarify step 7 server delivery code snippets

### DIFF
--- a/docs/tutorial/10-server-delivery.md
+++ b/docs/tutorial/10-server-delivery.md
@@ -272,10 +272,55 @@ The client will then keep track of the offset:
 
 And finally the server will send the missing messages upon (re)connection:
 
+<Tabs groupId="lang">
+  <TabItem value="cjs" label="CommonJS" default>
+
 ```js title="index.js"
 // [...]
 
+  // highlight-next-line
+  io.on('connection', async (socket) => {
+    // highlight-next-line
+    socket.on('chat message', async (msg) => {
+      let result;
+      try {
+        result = await db.run('INSERT INTO messages (content) VALUES (?)', msg);
+      } catch (e) {
+        // TODO handle the failure
+        return;
+      }
+      io.emit('chat message', msg, result.lastID);
+    });
+
+    // highlight-start
+    if (!socket.recovered) {
+      // if the connection state recovery was not successful
+      try {
+        await db.each('SELECT id, content FROM messages WHERE id > ?',
+          [socket.handshake.auth.serverOffset || 0],
+          (_err, row) => {
+            socket.emit('chat message', row.content, row.id);
+          }
+        )
+      } catch (e) {
+        // something went wrong
+      }
+    }
+    // highlight-end
+  });
+
+// [...]
+```
+
+  </TabItem>
+  <TabItem value="mjs" label="ES modules">
+
+```js title="index.js"
+// [...]
+
+// highlight-next-line
 io.on('connection', async (socket) => {
+  // highlight-next-line
   socket.on('chat message', async (msg) => {
     let result;
     try {
@@ -306,6 +351,9 @@ io.on('connection', async (socket) => {
 
 // [...]
 ```
+
+  </TabItem>
+</Tabs>
 
 Let's see it in action:
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR resolves an issue with the "Step #7 Server delivery" tutorial where the final code snippet was presented as a single combined block without differentiating between CommonJS and ES Modules. 

Users using CommonJS encountered a `SyntaxError: Unexpected reserved word` due to the top-level `await` because the implicit `async function main()` wrapper wasn't shown in the snippet. Additionally, the `async` keyword was added silently without any highlighting, causing confusion.

### Changes Made:
- Split the final combined code block into `<Tabs>` with `cjs` and `mjs` variants, matching the style established in previous tutorial steps.
- Properly added `// highlight-next-line` immediately before the `io.on('connection', async (socket)` and `socket.on('chat message', async (msg)` lines so students are aware of the newly introduced `async` keywords.

Fixes #512