### PR TITLE
docs: add global middleware section to middlewares page (fixes #4609)

### DIFF
--- a/docs/categories/02-Server/middlewares.md
+++ b/docs/categories/02-Server/middlewares.md
@@ -192,3 +192,28 @@ io.engine.use((req, res, next) => {
   }
 });
 ```
+
+## Applying middleware to all namespaces
+
+By default, a middleware registered with `io.use()` only applies to the main namespace (`/`). If you need a middleware to run for **all namespaces**, you can use the [`new_namespace`](/docs/v4/server-api/#event-new_namespace) event:
+
+```js
+const myMiddleware = (socket, next) => {
+  // ...
+  next();
+};
+
+io.use(myMiddleware);
+
+io.on("new_namespace", (namespace) => {
+  namespace.use(myMiddleware);
+});
+```
+
+:::caution
+
+Namespaces registered before the `new_namespace` listener is added will not be affected.
+
+:::
+
+For more details and additional patterns (manual registration, dynamic namespaces), see [How to register a global middleware](/how-to/register-a-global-middleware).


### PR DESCRIPTION
## Description

The `/docs/v4/middlewares/` page only showed middleware examples for the main namespace (`/`), 
with no mention of how to apply middleware globally across all namespaces.

This was confusing because the existing how-to guide (`/how-to/register-a-global-middleware`) 
already covered this topic but was not discoverable from the main middleware docs page.

## Changes

- Added a new "Applying middleware to all namespaces" section at the bottom of the middlewares page
- Shows how to use the `new_namespace` event to register global middleware
- Includes a caution about namespace registration order
- Links to the existing how-to guide for additional patterns (manual registration, dynamic namespaces)

## Related

Fixes socketio/socket.io#4609