### PR TITLE
docs: clarify server.on() and server.emit() are aliases for the main namespace

### DIFF
--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -366,7 +366,7 @@ See [here](categories/02-Server/server-instance.md#utility-methods).
 - `args` `any[]`
 - **Returns** `true`
 
-Emits an event to all connected clients in the main namespace.
+Alias for [`io.of("/").emit()`](#namespaceemiteventname-args). Emits an event to all connected clients in the main namespace.
 
 ```js
 io.emit("hello");
@@ -593,7 +593,7 @@ io.of((name, query, next) => {
 - `listener` [`<Function>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 - **Returns** [`<Server>`](#server)
 
-Adds the `listener` function to the end of the listeners array for the event named `eventName`.
+Alias for [`io.of("/").on(eventName, listener)`](#namespaceon). Adds the `listener` function to the end of the listeners array for the event named `eventName`.
 
 Available events:
 


### PR DESCRIPTION
## Description

The Server API docs showed examples of `io.on()` and `io.emit()` but never explained 
that these are aliases for the main namespace (`/`), which was confusing for new users.

Other methods like `server.use()`, `server.fetchSockets()`, and `server.disconnectSockets()` 
already had "Alias for `io.of("/")...`" notes — this PR makes `server.on()` and 
`server.emit()` consistent with that pattern.

## Changes

- Added alias note to `server.on()` clarifying it maps to `io.of("/").on()`
- Added alias note to `server.emit()` clarifying it maps to `io.of("/").emit()`

## Related

Fixes socketio/socket.io#4608